### PR TITLE
Add Supabase JWT auth and frontend AuthContext

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -9,7 +9,15 @@ const userRoutes = require("./routes/user.routes");
 const app = express();
 
 app.use(helmet());
-app.use(cors());
+app.use(cors({
+  origin: [
+    "http://localhost:5173",
+    "http://localhost:3000",
+    "https://adorixit.com",
+    "https://www.adorixit.com"
+  ],
+  credentials: true
+}));
 app.use(express.json());
 app.use(morgan("dev"));
 

--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -1,29 +1,39 @@
 const userService = require('../services/user.service');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+
+const JWT_SECRET = process.env.JWT_SECRET;
+const JWT_EXPIRES_IN = '7d'; // Token valid for 7 days
 
 /**
- * Authentication Controller
+ * Authentication Controller - Supabase + JWT + bcrypt
  */
 const signup = async (req, res) => {
     try {
         const { name, email, password } = req.body;
 
-        // Simple validation
         if (!name || !email || !password) {
             return res.status(400).json({ error: 'Name, email, and password are required' });
         }
 
+        // Check if user already exists
         const existingUser = await userService.findUserByEmail(email);
         if (existingUser) {
-            return res.status(400).json({ error: 'User already exists' });
+            return res.status(400).json({ error: 'An account with this email already exists. Please sign in.' });
         }
 
+        // Create user (password hashed inside userService)
         const user = await userService.createUser({ name, email, password });
 
-        // Create mock token
-        const token = `mock-token-${user.id}`;
+        // Sign a real JWT
+        const token = jwt.sign(
+            { userId: user.id, email: user.email },
+            JWT_SECRET,
+            { expiresIn: JWT_EXPIRES_IN }
+        );
 
         res.status(201).json({
-            message: 'User created successfully',
+            message: 'Account created successfully',
             token,
             user: {
                 id: user.id,
@@ -32,7 +42,8 @@ const signup = async (req, res) => {
             }
         });
     } catch (error) {
-        res.status(500).json({ error: 'Internal server error' });
+        console.error('Signup error:', error.message);
+        res.status(500).json({ error: 'Something went wrong. Please try again.' });
     }
 };
 
@@ -44,13 +55,24 @@ const login = async (req, res) => {
             return res.status(400).json({ error: 'Email and password are required' });
         }
 
+        // Find user in Supabase
         const user = await userService.findUserByEmail(email);
-        if (!user || user.password !== password) {
-            return res.status(401).json({ error: 'Invalid credentials' });
+        if (!user) {
+            return res.status(401).json({ error: 'USER_NOT_FOUND' });
         }
 
-        // Create mock token
-        const token = `mock-token-${user.id}`;
+        // Compare hashed password
+        const isPasswordValid = await bcrypt.compare(password, user.password);
+        if (!isPasswordValid) {
+            return res.status(401).json({ error: 'Incorrect password. Please try again.' });
+        }
+
+        // Sign a real JWT
+        const token = jwt.sign(
+            { userId: user.id, email: user.email },
+            JWT_SECRET,
+            { expiresIn: JWT_EXPIRES_IN }
+        );
 
         res.status(200).json({
             message: 'Login successful',
@@ -62,13 +84,13 @@ const login = async (req, res) => {
             }
         });
     } catch (error) {
-        res.status(500).json({ error: 'Internal server error' });
+        console.error('Login error:', error.message);
+        res.status(500).json({ error: 'Something went wrong. Please try again.' });
     }
 };
 
 const me = async (req, res) => {
     try {
-        // req.user is attached by authMiddleware
         if (!req.user) {
             return res.status(401).json({ error: 'Unauthorized' });
         }
@@ -85,8 +107,4 @@ const me = async (req, res) => {
     }
 };
 
-module.exports = {
-    signup,
-    login,
-    me
-};
+module.exports = { signup, login, me };

--- a/backend/src/lib/supabase.js
+++ b/backend/src/lib/supabase.js
@@ -1,0 +1,12 @@
+const { createClient } = require('@supabase/supabase-js');
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+    throw new Error('Missing SUPABASE_URL or SUPABASE_ANON_KEY in .env');
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+module.exports = supabase;

--- a/backend/src/middlewares/auth.middleware.js
+++ b/backend/src/middlewares/auth.middleware.js
@@ -1,31 +1,43 @@
+const jwt = require('jsonwebtoken');
 const userService = require('../services/user.service');
 
+const JWT_SECRET = process.env.JWT_SECRET;
+
 /**
- * Mock Authentication Middleware
- * Validates token in Authorization header: Mock-token-<id>
+ * JWT Authentication Middleware
+ * Validates Bearer token in Authorization header
  */
 const authMiddleware = async (req, res, next) => {
     try {
         const authHeader = req.headers.authorization;
 
-        if (!authHeader || !authHeader.startsWith('mock-token-')) {
-            return res.status(401).json({ error: 'No token provided or invalid token format' });
+        if (!authHeader || !authHeader.startsWith('Bearer ')) {
+            return res.status(401).json({ error: 'No token provided. Please sign in.' });
         }
 
-        const userId = authHeader.split('-')[2];
-        if (!userId) {
-            return res.status(401).json({ error: 'Invalid token' });
+        const token = authHeader.split(' ')[1];
+
+        // Verify the JWT
+        let decoded;
+        try {
+            decoded = jwt.verify(token, JWT_SECRET);
+        } catch (err) {
+            if (err.name === 'TokenExpiredError') {
+                return res.status(401).json({ error: 'Session expired. Please sign in again.' });
+            }
+            return res.status(401).json({ error: 'Invalid token. Please sign in again.' });
         }
 
-        const user = await userService.findUserById(userId);
+        // Fetch the user from Supabase using userId from token
+        const user = await userService.findUserById(decoded.userId);
         if (!user) {
-            return res.status(401).json({ error: 'Unauthorized' });
+            return res.status(401).json({ error: 'User not found. Please sign in again.' });
         }
 
-        // Attach user to request object
         req.user = user;
         next();
     } catch (error) {
+        console.error('Auth middleware error:', error.message);
         res.status(500).json({ error: 'Internal server error' });
     }
 };

--- a/backend/src/services/user.service.js
+++ b/backend/src/services/user.service.js
@@ -1,52 +1,67 @@
-/**
- * In-memory Mock User Storage
- */
+const supabase = require('../lib/supabase');
+const bcrypt = require('bcryptjs');
+
 class UserService {
-    constructor() {
-        this.users = [];
-        this.currentId = 1;
-    }
 
     async createUser({ name, email, password }) {
-        const user = {
-            id: this.currentId++,
-            name,
-            email,
-            password, // In a real app, this should be hashed
-            createdAt: new Date().toISOString()
-        };
-        this.users.push(user);
-        return user;
+        const hashedPassword = await bcrypt.hash(password, 12);
+
+        const { data, error } = await supabase
+            .from('users')
+            .insert([{ name, email, password: hashedPassword }])
+            .select('id, name, email, created_at')
+            .single();
+
+        if (error) {
+            throw new Error(error.message);
+        }
+        return data;
     }
 
     async findUserByEmail(email) {
-        return this.users.find(u => u.email === email);
+        const { data, error } = await supabase
+            .from('users')
+            .select('*')
+            .eq('email', email)
+            .single();
+
+        if (error && error.code !== 'PGRST116') {
+            // PGRST116 = row not found, which is fine
+            throw new Error(error.message);
+        }
+        return data || null;
     }
 
     async findUserById(id) {
-        return this.users.find(u => u.id === parseInt(id));
+        const { data, error } = await supabase
+            .from('users')
+            .select('id, name, email, created_at')
+            .eq('id', id)
+            .single();
+
+        if (error && error.code !== 'PGRST116') {
+            throw new Error(error.message);
+        }
+        return data || null;
     }
 
     async updateUser(id, updateData) {
-        const userIndex = this.users.findIndex(u => u.id === parseInt(id));
-        if (userIndex === -1) {
-            return null;
-        }
-
-        // Only allow updating specific fields
         const allowedUpdates = {};
         if (updateData.name !== undefined) allowedUpdates.name = updateData.name;
         if (updateData.company !== undefined) allowedUpdates.company = updateData.company;
         if (updateData.phone !== undefined) allowedUpdates.phone = updateData.phone;
 
-        // Merge allowed updates with existing user data
-        this.users[userIndex] = {
-            ...this.users[userIndex],
-            ...allowedUpdates,
-            updatedAt: new Date().toISOString()
-        };
+        const { data, error } = await supabase
+            .from('users')
+            .update(allowedUpdates)
+            .eq('id', id)
+            .select('id, name, email, created_at')
+            .single();
 
-        return this.users[userIndex];
+        if (error) {
+            throw new Error(error.message);
+        }
+        return data;
     }
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,8 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import Navbar from './components/layout/navbar';
 import MainLayout from './components/layout/MainLayout';
 import ScrollToTop from './components/common/ScrollToTop';
+import ProtectedRoute from './components/ProtectedRoute';
+import { AuthProvider } from './context/AuthContext';
 
 // Pages
 import Home from './pages/pagesonNav/Home';
@@ -10,6 +11,7 @@ import Contact from './pages/pagesonNav/Contact';
 import Login from './pages/auth/Login';
 import Signup from './pages/auth/Signup';
 import Verification from './pages/auth/Verification';
+import ForgotPassword from './pages/auth/ForgotPassword';
 import Dashboard from './pages/pagesonNav/Dashboard';
 import CampaignStudio from './pages/pagesonNav/CampaignStudio';
 import Profile from './pages/pagesonNav/Profile';
@@ -18,7 +20,7 @@ import PaymentMethod from './pages/pagesonNav/payment/PaymentMethod';
 import UpgradePlan from './pages/pagesonNav/payment/UpgradePlan';
 import Checkout from './pages/pagesonNav/payment/Checkout';
 
-// New Settings Pages (Ensure these files exist in src/pages/settings/)
+// Settings Pages
 import AccountInfo from './pages/settings/AccountInfo';
 import Security from './pages/settings/Security';
 import Policies from './pages/settings/Policies';
@@ -27,40 +29,43 @@ import Feedback from './pages/settings/Feedback';
 
 function App() {
   return (
-    <Router>
-      <ScrollToTop />
-      <Routes>
-        <Route element={<MainLayout />}>
-          {/* Public Routes */}
-          <Route path="/" element={<Home />} />
-          <Route path="/features" element={<Features />} />
-          <Route path="/contact" element={<Contact />} />
-          <Route path="/pricing" element={<Pricing />} />
+    <AuthProvider>
+      <Router>
+        <ScrollToTop />
+        <Routes>
+          <Route element={<MainLayout />}>
+            {/* Public Routes */}
+            <Route path="/" element={<Home />} />
+            <Route path="/features" element={<Features />} />
+            <Route path="/contact" element={<Contact />} />
+            <Route path="/pricing" element={<Pricing />} />
 
-          {/* Auth Routes */}
-          <Route path="/login" element={<Login />} />
-          <Route path="/signup" element={<Signup />} />
-          <Route path="/verify" element={<Verification />} />
+            {/* Auth Routes */}
+            <Route path="/login" element={<Login />} />
+            <Route path="/signup" element={<Signup />} />
+            <Route path="/verify" element={<Verification />} />
+            <Route path="/forgot-password" element={<ForgotPassword />} />
 
-          {/* Protected Dashboard Routes */}
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/dashboard/studio" element={<CampaignStudio />} />
-          <Route path="/profile" element={<Profile />} />
+            {/* Protected Dashboard Routes */}
+            <Route path="/dashboard" element={<ProtectedRoute><Dashboard /></ProtectedRoute>} />
+            <Route path="/dashboard/studio" element={<ProtectedRoute><CampaignStudio /></ProtectedRoute>} />
+            <Route path="/profile" element={<ProtectedRoute><Profile /></ProtectedRoute>} />
 
-          {/* Payment */}
-          <Route path="/payment-method" element={<PaymentMethod />} />
-          <Route path="/upgrade/:plan" element={<UpgradePlan />} />
-          <Route path="/checkout/:plan/:method" element={<Checkout />} />
+            {/* Protected Payment Routes */}
+            <Route path="/payment-method" element={<ProtectedRoute><PaymentMethod /></ProtectedRoute>} />
+            <Route path="/upgrade/:plan" element={<ProtectedRoute><UpgradePlan /></ProtectedRoute>} />
+            <Route path="/checkout/:plan/:method" element={<ProtectedRoute><Checkout /></ProtectedRoute>} />
 
-          {/* Settings Module Routes */}
-          <Route path="/settings/account" element={<AccountInfo />} />
-          <Route path="/settings/security" element={<Security />} />
-          <Route path="/settings/policies" element={<Policies />} />
-          <Route path="/settings/help" element={<Help />} />
-          <Route path="/settings/feedback" element={<Feedback />} />
-        </Route>
-      </Routes>
-    </Router>
+            {/* Protected Settings Routes */}
+            <Route path="/settings/account" element={<ProtectedRoute><AccountInfo /></ProtectedRoute>} />
+            <Route path="/settings/security" element={<ProtectedRoute><Security /></ProtectedRoute>} />
+            <Route path="/settings/policies" element={<ProtectedRoute><Policies /></ProtectedRoute>} />
+            <Route path="/settings/help" element={<ProtectedRoute><Help /></ProtectedRoute>} />
+            <Route path="/settings/feedback" element={<ProtectedRoute><Feedback /></ProtectedRoute>} />
+          </Route>
+        </Routes>
+      </Router>
+    </AuthProvider>
   );
 }
 

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+const ProtectedRoute = ({ children }) => {
+    const { isAuthenticated, loading } = useAuth();
+    const location = useLocation();
+
+    if (loading) {
+        // Show a simple spinner while checking auth state
+        return (
+            <div className="flex items-center justify-center min-h-screen">
+                <div className="w-12 h-12 border-4 border-adorix-primary border-t-transparent rounded-full animate-spin" />
+            </div>
+        );
+    }
+
+    if (!isAuthenticated) {
+        // Redirect to login and remember where they were trying to go
+        return <Navigate to="/login" state={{ from: location, error: 'Please sign in to access this page.' }} replace />;
+    }
+
+    return children;
+};
+
+export default ProtectedRoute;

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,3 @@
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000/api';
+
+export default API_URL;

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,50 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+const AuthContext = createContext(null);
+
+export const AuthProvider = ({ children }) => {
+    const [user, setUser] = useState(null);
+    const [token, setToken] = useState(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        // On app load, restore session from localStorage
+        const savedToken = localStorage.getItem('auth_token');
+        const savedUser = localStorage.getItem('auth_user');
+        if (savedToken && savedUser) {
+            setToken(savedToken);
+            setUser(JSON.parse(savedUser));
+        }
+        setLoading(false);
+    }, []);
+
+    const login = (userData, authToken) => {
+        setUser(userData);
+        setToken(authToken);
+        localStorage.setItem('auth_token', authToken);
+        localStorage.setItem('auth_user', JSON.stringify(userData));
+    };
+
+    const logout = () => {
+        setUser(null);
+        setToken(null);
+        localStorage.removeItem('auth_token');
+        localStorage.removeItem('auth_user');
+    };
+
+    const isAuthenticated = !!token && !!user;
+
+    return (
+        <AuthContext.Provider value={{ user, token, loading, login, logout, isAuthenticated }}>
+            {children}
+        </AuthContext.Provider>
+    );
+};
+
+export const useAuth = () => {
+    const context = useContext(AuthContext);
+    if (!context) {
+        throw new Error('useAuth must be used within an AuthProvider');
+    }
+    return context;
+};

--- a/src/pages/auth/ForgotPassword.jsx
+++ b/src/pages/auth/ForgotPassword.jsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { motion, AnimatePresence } from 'framer-motion';
+
+const ForgotPassword = () => {
+    const [email, setEmail] = useState('');
+    const [submitted, setSubmitted] = useState(false);
+    const [error, setError] = useState('');
+    const [loading, setLoading] = useState(false);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        if (!email) {
+            setError('Please enter your email address.');
+            return;
+        }
+
+        setLoading(true);
+        setError('');
+
+        // This would be a real API call in a full implementation
+        setTimeout(() => {
+            setSubmitted(true);
+            setLoading(false);
+        }, 1500);
+    };
+
+    return (
+        <div className="pt-28 pb-24 flex justify-center items-center min-h-[80vh]">
+            <div className="bg-white p-10 rounded-2xl shadow-xl border border-gray-100 w-full max-w-md text-center">
+                {!submitted ? (
+                    <>
+                        <h2 className="text-3xl font-bold text-adorix-dark mb-2">Reset Password</h2>
+                        <p className="text-gray-500 mb-8">Enter your email to receive a password reset link.</p>
+
+                        <AnimatePresence>
+                            {error && (
+                                <motion.div
+                                    initial={{ opacity: 0, y: -8 }}
+                                    animate={{ opacity: 1, y: 0 }}
+                                    exit={{ opacity: 0, y: -8 }}
+                                    className="mb-5 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-red-600 text-sm font-medium"
+                                >
+                                    {error}
+                                </motion.div>
+                            )}
+                        </AnimatePresence>
+
+                        <form onSubmit={handleSubmit} className="space-y-6">
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1 text-left">Email Address</label>
+                                <input
+                                    type="email"
+                                    value={email}
+                                    onChange={(e) => setEmail(e.target.value)}
+                                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-adorix-primary focus:outline-none transition"
+                                    placeholder="you@example.com"
+                                />
+                            </div>
+
+                            <button
+                                type="submit"
+                                disabled={loading}
+                                className="w-full bg-adorix-dark hover:bg-adorix-primary text-white font-bold py-3 rounded-lg transition shadow-md disabled:opacity-60 flex items-center justify-center gap-2"
+                            >
+                                {loading ? (
+                                    <>
+                                        <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                                        Sending...
+                                    </>
+                                ) : 'Send Reset Link'}
+                            </button>
+                        </form>
+                    </>
+                ) : (
+                    <motion.div
+                        initial={{ opacity: 0, scale: 0.95 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        className="py-4"
+                    >
+                        <div className="w-16 h-16 bg-green-100 text-green-600 rounded-full flex items-center justify-center mx-auto mb-6 text-2xl">
+                            ✓
+                        </div>
+                        <h2 className="text-3xl font-bold text-adorix-dark mb-2">Check your email</h2>
+                        <p className="text-gray-500 mb-8">
+                            We've sent a password reset link to <span className="font-semibold text-gray-800">{email}</span>.
+                        </p>
+                    </motion.div>
+                )}
+
+                <div className="mt-8 pt-6 border-t border-gray-100">
+                    <Link to="/login" className="text-adorix-primary font-semibold hover:underline">
+                        Back to Sign In
+                    </Link>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ForgotPassword;

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -1,12 +1,19 @@
 import React, { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useGoogleLogin } from '@react-oauth/google';
 import { motion, AnimatePresence } from 'framer-motion';
+import { useAuth } from '../../context/AuthContext';
+import API_URL from '../../config';
 
 const Login = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+  const { login } = useAuth();
+
   const [form, setForm] = useState({ email: '', password: '', rememberMe: false });
   const [errors, setErrors] = useState({});
+  const [serverError, setServerError] = useState(location.state?.error || '');
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     const savedEmail = localStorage.getItem('remember_me_email');
@@ -30,16 +37,12 @@ const Login = () => {
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
-    setForm({
-      ...form,
-      [name]: type === 'checkbox' ? checked : value
-    });
-    if (errors[name]) {
-      setErrors({ ...errors, [name]: '' });
-    }
+    setForm({ ...form, [name]: type === 'checkbox' ? checked : value });
+    if (errors[name]) setErrors({ ...errors, [name]: '' });
+    if (serverError) setServerError('');
   };
 
-  const handleLogin = (e) => {
+  const handleLogin = async (e) => {
     e.preventDefault();
     const validationErrors = validate();
     if (Object.keys(validationErrors).length > 0) {
@@ -47,22 +50,51 @@ const Login = () => {
       return;
     }
 
-    if (form.rememberMe) {
-      localStorage.setItem('remember_me_email', form.email);
-    } else {
-      localStorage.removeItem('remember_me_email');
-    }
+    setLoading(true);
+    setServerError('');
 
-    // Handle standard login logic here
-    navigate('/dashboard');
+    try {
+      const response = await fetch(`${API_URL}/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: form.email, password: form.password }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        if (data.error === 'USER_NOT_FOUND') {
+          // Navigate to signup with the email already populated
+          navigate('/signup', { state: { email: form.email, info: 'No account found with this email. Please sign up first!' } });
+          return;
+        }
+        setServerError(data.error || 'Login failed. Please try again.');
+        return;
+      }
+
+      if (form.rememberMe) {
+        localStorage.setItem('remember_me_email', form.email);
+      } else {
+        localStorage.removeItem('remember_me_email');
+      }
+
+      // Store token + user in AuthContext
+      login(data.user, data.token);
+
+      // Redirect to home or where they came from
+      const from = location.state?.from?.pathname || '/';
+      navigate(from, { replace: true });
+    } catch (err) {
+      setServerError('Cannot connect to server. Make sure the backend is running.');
+    } finally {
+      setLoading(false);
+    }
   };
 
-  // Google Login Functionality
   const googleLogin = useGoogleLogin({
     onSuccess: (tokenResponse) => {
       console.log('Google Login Success:', tokenResponse);
-      // Here you would typically send tokenResponse.access_token to your backend
-      navigate('/dashboard');
+      navigate('/');
     },
     onError: (error) => console.log('Google Login Failed:', error),
   });
@@ -72,6 +104,20 @@ const Login = () => {
       <div className="bg-white p-10 rounded-2xl shadow-xl border border-gray-100 w-full max-w-md">
         <h2 className="text-3xl font-bold text-adorix-dark mb-2">Welcome back</h2>
         <p className="text-gray-500 mb-8">Sign in to your Adorix dashboard</p>
+
+        {/* Server Error Banner */}
+        <AnimatePresence>
+          {serverError && (
+            <motion.div
+              initial={{ opacity: 0, y: -8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              className="mb-5 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-red-600 text-sm font-medium"
+            >
+              {serverError}
+            </motion.div>
+          )}
+        </AnimatePresence>
 
         <form onSubmit={handleLogin} className="space-y-5" noValidate>
           {/* Email */}
@@ -92,7 +138,6 @@ const Login = () => {
                   initial={{ opacity: 0, height: 0, marginTop: 0 }}
                   animate={{ opacity: 1, height: 'auto', marginTop: 4 }}
                   exit={{ opacity: 0, height: 0, marginTop: 0 }}
-                  aria-live="assertive"
                   className="text-red-500 text-xs overflow-hidden"
                 >
                   {errors.email}
@@ -105,7 +150,7 @@ const Login = () => {
           <div>
             <div className="flex justify-between items-center mb-1">
               <label className="block text-sm font-medium text-gray-700">Password</label>
-              <Link to="#" className="text-xs text-adorix-primary font-medium hover:underline">Forgot password?</Link>
+              <Link to="/forgot-password" virtual-element="forgot-password" className="text-xs text-adorix-primary font-medium hover:underline">Forgot password?</Link>
             </div>
             <input
               type="password"
@@ -121,7 +166,6 @@ const Login = () => {
                   initial={{ opacity: 0, height: 0, marginTop: 0 }}
                   animate={{ opacity: 1, height: 'auto', marginTop: 4 }}
                   exit={{ opacity: 0, height: 0, marginTop: 0 }}
-                  aria-live="assertive"
                   className="text-red-500 text-xs overflow-hidden"
                 >
                   {errors.password}
@@ -152,7 +196,7 @@ const Login = () => {
             <div className="flex-1 h-px bg-gray-200" />
           </div>
 
-          {/* Google Sign In - NOW FUNCTIONAL */}
+          {/* Google Sign In */}
           <button
             type="button"
             onClick={() => googleLogin()}
@@ -168,8 +212,17 @@ const Login = () => {
           </button>
 
           {/* Submit */}
-          <button type="submit" className="w-full bg-adorix-dark hover:bg-adorix-primary text-white font-bold py-3 rounded-lg transition shadow-md">
-            Sign In
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-adorix-dark hover:bg-adorix-primary text-white font-bold py-3 rounded-lg transition shadow-md disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          >
+            {loading ? (
+              <>
+                <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                Signing in...
+              </>
+            ) : 'Sign In'}
           </button>
         </form>
 
@@ -177,8 +230,8 @@ const Login = () => {
           Don't have an account?{' '}
           <Link to="/signup" className="text-adorix-primary font-semibold hover:underline">Sign up</Link>
         </p>
-      </div >
-    </div >
+      </div>
+    </div>
   );
 };
 

--- a/src/pages/auth/Signup.jsx
+++ b/src/pages/auth/Signup.jsx
@@ -1,12 +1,23 @@
 import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useGoogleLogin } from '@react-oauth/google';
 import { motion, AnimatePresence } from 'framer-motion';
+import { useAuth } from '../../context/AuthContext';
+import API_URL from '../../config';
 
 const Signup = () => {
-  const navigate = useNavigate();
-  const [form, setForm] = useState({ name: '', email: '', password: '' });
+  const location = useLocation();
+  const { login } = useAuth();
+
+  const [form, setForm] = useState({
+    name: '',
+    email: location.state?.email || '',
+    password: ''
+  });
   const [errors, setErrors] = useState({});
+  const [serverError, setServerError] = useState('');
+  const [infoMessage, setInfoMessage] = useState(location.state?.info || '');
+  const [loading, setLoading] = useState(false);
 
   const passwordRequirements = [
     { label: '8+ characters', test: (pwd) => pwd.length >= 8 },
@@ -17,22 +28,17 @@ const Signup = () => {
 
   const validate = () => {
     const newErrors = {};
-    if (!form.name.trim()) {
-      newErrors.name = 'Full name is required.';
-    }
+    if (!form.name.trim()) newErrors.name = 'Full name is required.';
     if (!form.email.trim()) {
       newErrors.email = 'Email is required.';
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email)) {
       newErrors.email = 'Please enter a valid email address.';
     }
-
     if (!form.password) {
       newErrors.password = 'Password is required.';
     } else {
       const failed = passwordRequirements.filter(req => !req.test(form.password));
-      if (failed.length > 0) {
-        newErrors.password = 'Password does not meet all security requirements.';
-      }
+      if (failed.length > 0) newErrors.password = 'Password does not meet all security requirements.';
     }
     return newErrors;
   };
@@ -40,47 +46,61 @@ const Signup = () => {
   const suggestPassword = () => {
     const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
     const nums = "0123456789";
-    const symbols = "!@#$%^&*()_+~`|}{[]:;?><,./-=";
-
-    let pwd = "";
-    pwd += chars.charAt(Math.floor(Math.random() * chars.length));
-    pwd += nums.charAt(Math.floor(Math.random() * nums.length));
-    pwd += symbols.charAt(Math.floor(Math.random() * symbols.length));
-
+    const symbols = "!@#$%^&*()_+~";
+    let pwd = chars[Math.floor(Math.random() * chars.length)] +
+      nums[Math.floor(Math.random() * nums.length)] +
+      symbols[Math.floor(Math.random() * symbols.length)];
     const all = chars + nums + symbols;
-    for (let i = 0; i < 9; i++) {
-      pwd += all.charAt(Math.floor(Math.random() * all.length));
-    }
-
-    // Shuffle
+    for (let i = 0; i < 9; i++) pwd += all[Math.floor(Math.random() * all.length)];
     pwd = pwd.split('').sort(() => 0.5 - Math.random()).join('');
-
     setForm({ ...form, password: pwd });
     if (errors.password) setErrors({ ...errors, password: '' });
   };
 
   const handleChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });
-    if (errors[e.target.name]) {
-      setErrors({ ...errors, [e.target.name]: '' });
-    }
+    if (errors[e.target.name]) setErrors({ ...errors, [e.target.name]: '' });
+    if (serverError) setServerError('');
   };
 
-  const handleSignup = (e) => {
+  const handleSignup = async (e) => {
     e.preventDefault();
     const validationErrors = validate();
     if (Object.keys(validationErrors).length > 0) {
       setErrors(validationErrors);
       return;
     }
-    navigate('/verify');
+
+    setLoading(true);
+    setServerError('');
+
+    try {
+      const response = await fetch(`${API_URL}/auth/signup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: form.name, email: form.email, password: form.password }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        setServerError(data.error || 'Signup failed. Please try again.');
+        return;
+      }
+
+      // Automatically log the user in after signup
+      login(data.user, data.token);
+      navigate('/', { replace: true });
+    } catch (err) {
+      setServerError('Cannot connect to server. Make sure the backend is running.');
+    } finally {
+      setLoading(false);
+    }
   };
 
-  // Google Signup Functionality
   const googleSignup = useGoogleLogin({
     onSuccess: (tokenResponse) => {
       console.log('Google Signup Success:', tokenResponse);
-      // Logic for creating account via Google
       navigate('/verify');
     },
     onError: (error) => console.log('Google Signup Failed:', error),
@@ -91,6 +111,34 @@ const Signup = () => {
       <div className="bg-white p-10 rounded-2xl shadow-xl border border-gray-100 w-full max-w-md">
         <h2 className="text-3xl font-bold text-adorix-dark mb-2">Create account</h2>
         <p className="text-gray-500 mb-8">Join the ad revolution today.</p>
+
+        {/* Info Message Banner */}
+        <AnimatePresence>
+          {infoMessage && (
+            <motion.div
+              initial={{ opacity: 0, y: -8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              className="mb-5 px-4 py-3 bg-blue-50 border border-blue-200 rounded-lg text-blue-600 text-sm font-medium"
+            >
+              {infoMessage}
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Server Error Banner */}
+        <AnimatePresence>
+          {serverError && (
+            <motion.div
+              initial={{ opacity: 0, y: -8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              className="mb-5 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-red-600 text-sm font-medium"
+            >
+              {serverError}
+            </motion.div>
+          )}
+        </AnimatePresence>
 
         <form onSubmit={handleSignup} className="space-y-5" noValidate>
           {/* Full Name */}
@@ -107,13 +155,7 @@ const Signup = () => {
             />
             <AnimatePresence>
               {errors.name && (
-                <motion.p
-                  initial={{ opacity: 0, height: 0, marginTop: 0 }}
-                  animate={{ opacity: 1, height: 'auto', marginTop: 4 }}
-                  exit={{ opacity: 0, height: 0, marginTop: 0 }}
-                  aria-live="assertive"
-                  className="text-red-500 text-xs overflow-hidden"
-                >
+                <motion.p initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: 'auto', marginTop: 4 }} exit={{ opacity: 0, height: 0 }} className="text-red-500 text-xs overflow-hidden">
                   {errors.name}
                 </motion.p>
               )}
@@ -133,13 +175,7 @@ const Signup = () => {
             />
             <AnimatePresence>
               {errors.email && (
-                <motion.p
-                  initial={{ opacity: 0, height: 0, marginTop: 0 }}
-                  animate={{ opacity: 1, height: 'auto', marginTop: 4 }}
-                  exit={{ opacity: 0, height: 0, marginTop: 0 }}
-                  aria-live="assertive"
-                  className="text-red-500 text-xs overflow-hidden"
-                >
+                <motion.p initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: 'auto', marginTop: 4 }} exit={{ opacity: 0, height: 0 }} className="text-red-500 text-xs overflow-hidden">
                   {errors.email}
                 </motion.p>
               )}
@@ -150,11 +186,7 @@ const Signup = () => {
           <div>
             <div className="flex justify-between items-center mb-1">
               <label className="block text-sm font-medium text-gray-700">Password</label>
-              <button
-                type="button"
-                onClick={suggestPassword}
-                className="text-xs text-adorix-primary font-semibold hover:underline"
-              >
+              <button type="button" onClick={suggestPassword} className="text-xs text-adorix-primary font-semibold hover:underline">
                 Suggest Strong Password
               </button>
             </div>
@@ -176,9 +208,7 @@ const Signup = () => {
                     <div className={`w-3.5 h-3.5 rounded-full flex items-center justify-center transition ${isMet ? 'bg-green-500' : 'bg-gray-200'}`}>
                       {isMet && <svg className="w-2.5 h-2.5 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="4"><path d="M5 13l4 4L19 7" /></svg>}
                     </div>
-                    <span className={`text-[10px] font-medium transition ${isMet ? 'text-green-600' : 'text-gray-400'}`}>
-                      {req.label}
-                    </span>
+                    <span className={`text-[10px] font-medium transition ${isMet ? 'text-green-600' : 'text-gray-400'}`}>{req.label}</span>
                   </div>
                 );
               })}
@@ -186,13 +216,7 @@ const Signup = () => {
 
             {errors.password && (
               <AnimatePresence>
-                <motion.p
-                  initial={{ opacity: 0, height: 0, marginTop: 0 }}
-                  animate={{ opacity: 1, height: 'auto', marginTop: 8 }}
-                  exit={{ opacity: 0, height: 0, marginTop: 0 }}
-                  aria-live="assertive"
-                  className="text-red-500 text-xs overflow-hidden"
-                >
+                <motion.p initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: 'auto', marginTop: 8 }} exit={{ opacity: 0, height: 0 }} className="text-red-500 text-xs overflow-hidden">
                   {errors.password}
                 </motion.p>
               </AnimatePresence>
@@ -206,7 +230,7 @@ const Signup = () => {
             <div className="flex-1 h-px bg-gray-200" />
           </div>
 
-          {/* Google Sign Up - NOW FUNCTIONAL */}
+          {/* Google Sign Up */}
           <button
             type="button"
             onClick={() => googleSignup()}
@@ -222,8 +246,17 @@ const Signup = () => {
           </button>
 
           {/* Submit */}
-          <button type="submit" className="w-full bg-adorix-dark hover:bg-adorix-primary text-white font-bold py-3 rounded-lg transition shadow-md">
-            Create Account
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-adorix-dark hover:bg-adorix-primary text-white font-bold py-3 rounded-lg transition shadow-md disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          >
+            {loading ? (
+              <>
+                <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                Creating account...
+              </>
+            ) : 'Create Account'}
           </button>
         </form>
 
@@ -231,8 +264,8 @@ const Signup = () => {
           Already have an account?{' '}
           <Link to="/login" className="text-adorix-primary font-semibold hover:underline">Sign in</Link>
         </p>
-      </div >
-    </div >
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
Replace mock auth with real Supabase-backed auth and JWTs. Backend: add lib/supabase client, switch user.service to Supabase + bcrypt, sign JWTs in auth.controller, verify JWTs in auth.middleware, and tighten CORS origins. Frontend: add AuthContext (session persistence), ProtectedRoute component, API_URL config, ForgotPassword page, and update Login/Signup to call the API, handle server errors, loading states, remember-me, and auto-login after signup. Notes: requires SUPABASE_URL, SUPABASE_ANON_KEY and JWT_SECRET env vars and a users table in Supabase; CORS whitelist updated for local and production domains.